### PR TITLE
Fixing expiration date format

### DIFF
--- a/src/Paddle/Filters.php
+++ b/src/Paddle/Filters.php
@@ -79,7 +79,7 @@ class Filters {
 		} else if ($value < time()) {
 			throw new \InvalidArgumentException(\Paddle\Api::ERR_308, 308);
 		} else {
-			return date('Y-m-d H:i:s', $value);
+			return date('Y-m-d', $value);
 		}
 	}
 

--- a/tests/filters.php
+++ b/tests/filters.php
@@ -1,0 +1,13 @@
+<?php
+require_once __DIR__ . '/test_case.php';
+
+use Paddle\Filters;
+
+class FiltersTest extends Test_Case {
+
+	public function test_filter_expires()
+	{
+		$date = Filters::filter_expires(time());
+		$this->assertEquals(date('Y-m-d'), $date);
+	}
+}


### PR DESCRIPTION
The API custom checkout expects `expires` field date in the format YYYY-MM-DD (https://paddle.com/docs/api-custom-checkout)